### PR TITLE
부활 API 추가 및 수정

### DIFF
--- a/controllers/quiz.controller.ts
+++ b/controllers/quiz.controller.ts
@@ -7,7 +7,7 @@ import { QuizParticipant } from '../models/quiz/interface/I_quiz_participant';
 import { QuizOperation } from '../models/quiz/interface/I_quiz_operation';
 import getStringValueFromQuery from './etc/get_value_from_query';
 import validateParamWithData from '../models/commons/req_validator';
-import JSCQuizCalculate from '../models/quiz/jsc/quiz.calculate.jsc';
+import JSCQuizOperation from '../models/quiz/jsc/quiz.operation.jsc';
 
 const log = debug('tjl:controller:quiz');
 
@@ -127,7 +127,7 @@ async function calculateRound({
 
   const { result, data } = validateParamWithData<{ id: string }>(
     { id: festivalId },
-    JSCQuizCalculate,
+    JSCQuizOperation,
   );
   if (!result) {
     return res.status(400).end();
@@ -141,10 +141,40 @@ async function calculateRound({
   return res.json(resp);
 }
 
+/** 부활하기 - 많은 참가자가 죽었을 때, 현재 라운드 참가자 모두 부활 */
+async function reviveCurrentRoundParticipants({
+  query,
+  res,
+}: {
+  query: NextApiRequest['query'];
+  res: NextApiResponse;
+}) {
+  const festivalId = getStringValueFromQuery({ query, field: 'quiz_id' });
+  if (festivalId === undefined) {
+    return res.status(400).end();
+  }
+
+  const { result, data } = validateParamWithData<{ id: string }>(
+    { id: festivalId },
+    JSCQuizOperation,
+  );
+  if (!result) {
+    return res.status(400).end();
+  }
+
+  const resp = await quizOpsModel.reviveCurrentRoundParticipants({ festivalId: data.id });
+  log('[revive]: ', resp);
+  if (resp === null) {
+    return res.status(500).end();
+  }
+  return res.json(resp);
+}
+
 export default {
   findParticipant,
   updateParticipant,
   updateOperationInfo,
   findAllQuizFromBank,
   calculateRound,
+  reviveCurrentRoundParticipants,
 };

--- a/models/quiz/jsc/quiz.operation.jsc.ts
+++ b/models/quiz/jsc/quiz.operation.jsc.ts
@@ -1,7 +1,7 @@
 import { JSONSchema6 } from 'json-schema';
 
-const JSCQuizCalculate: JSONSchema6 = {
-  description: '라운드 정산',
+const JSCQuizOperation: JSONSchema6 = {
+  description: '퀴즈 운영',
   properties: {
     id: {
       type: 'string',
@@ -10,4 +10,4 @@ const JSCQuizCalculate: JSONSchema6 = {
   required: ['id'],
 };
 
-export default JSCQuizCalculate;
+export default JSCQuizOperation;

--- a/models/quiz/operation.client.service.ts
+++ b/models/quiz/operation.client.service.ts
@@ -66,3 +66,27 @@ export async function calculateQuizRound(args: { festivalId: string; isServer: b
     };
   }
 }
+
+/** 탈락자가 많이 발생했을 때, 부활 */
+export async function reviveCurrentRoundParticipants(args: {
+  festivalId: string;
+  isServer: boolean;
+}) {
+  const { isServer } = args;
+  const hostAndPort: string = getBaseUrl(isServer);
+  const url = `${hostAndPort}/api/quiz/${args.festivalId}/revive`;
+
+  try {
+    const resp = await requester<QuizOperation | null>({
+      option: {
+        url,
+        method: 'post',
+      },
+    });
+    return resp;
+  } catch (err) {
+    return {
+      status: 500,
+    };
+  }
+}

--- a/models/quiz/operation.model.ts
+++ b/models/quiz/operation.model.ts
@@ -54,22 +54,17 @@ async function saveDeadStatus({ festivalId }: { festivalId: string }) {
     );
 
     // alive=false 처리
-    const deadReqeusts = deadParticipants.map(
-      (deadParticipant: FirebaseFirestore.QueryDocumentSnapshot) =>
-        deadParticipant.ref.update({ ...deadParticipant.data(), alive: false }),
+    const deadReqeusts = deadParticipants.map((deadParticipant) =>
+      deadParticipant.ref.update({ alive: false }),
     );
     await Promise.all(deadReqeusts);
 
     // quiz에 alive_participants 업데이트
     const aliveParticipantCount =
       currnetRoundParticipantsSnap.docs.length - deadParticipants.length;
-    const festivalUpdatedData: QuizOperation = {
-      ...festivalData,
-      alive_participants: aliveParticipantCount,
-    };
-    await festivalSnap.ref.update(festivalUpdatedData);
+    await festivalSnap.ref.update({ alive_participants: aliveParticipantCount });
 
-    return festivalUpdatedData;
+    return { ...festivalData, alive_participants: aliveParticipantCount };
   } catch (err) {
     return null;
   }
@@ -90,19 +85,14 @@ async function reviveCurrentRoundParticipants({ festivalId }: { festivalId: stri
 
     const reviveReqeusts = currentRoundParticipantsSnap.docs
       .filter((participant) => participant.data().alive === false)
-      .map((deadParticipant: FirebaseFirestore.QueryDocumentSnapshot) =>
-        deadParticipant.ref.update({ ...deadParticipant.data(), alive: true }),
-      );
+      .map((deadParticipant) => deadParticipant.ref.update({ alive: true }));
     await Promise.all(reviveReqeusts);
 
     // quiz의 alive_participants 업데이트
-    const festivalUpdatedData: QuizOperation = {
-      ...festivalData,
-      alive_participants: currentRoundParticipantsSnap.docs.length,
-    };
-    await festivalSnap.ref.update(festivalUpdatedData);
+    const aliveParticipantCount = currentRoundParticipantsSnap.docs.length;
+    await festivalSnap.ref.update({ alive_participants: aliveParticipantCount });
 
-    return festivalUpdatedData;
+    return { ...festivalData, alive_participants: aliveParticipantCount };
   } catch (err) {
     return null;
   }

--- a/pages/api/quiz/[quiz_id]/calculate.ts
+++ b/pages/api/quiz/[quiz_id]/calculate.ts
@@ -5,8 +5,9 @@ import quizController from '../../../../controllers/quiz.controller';
 export default async function handle(req: NextApiRequest, res: NextApiResponse) {
   const { method, query } = req;
 
-  if (method !== 'POST') {
-    res.status(404).end();
+  if (method === 'POST') {
+    await quizController.calculateRound({ query, res });
   }
-  await quizController.calculateRound({ query, res });
+
+  res.status(404).end();
 }

--- a/pages/api/quiz/[quiz_id]/revive.ts
+++ b/pages/api/quiz/[quiz_id]/revive.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import quizController from '../../../../controllers/quiz.controller';
+
+export default async function handle(req: NextApiRequest, res: NextApiResponse) {
+  const { method, query } = req;
+
+  if (method === 'POST') {
+    await quizController.reviveCurrentRoundParticipants({ query, res });
+  }
+
+  res.status(404).end();
+}


### PR DESCRIPTION
### 😇 부활 API 추가

- 라운드에서 많은 탈락자가 발생하는 경우를 대비한다.
- 해당 라운드의 탈락자를 부활시킨다.

### 🔨 퀴즈 정산/부활 API 수정

- firebase에서 update는 수정할 부분만 넘기면 된다.
- calculate.ts 파일은 나중에 다른 method가 들어올 때 처리하기 편하도록 수정한다.