### PR TITLE
[FIX] yalive -> YAQUIZ

### DIFF
--- a/components/quiz/dashboard/cover.tsx
+++ b/components/quiz/dashboard/cover.tsx
@@ -30,7 +30,7 @@ const Cover: React.FC<CoverProps> = ({ active, status }) => {
   return (
     <animated.section className={styles.container} style={containerStyle}>
       <div>
-        <h1 className={styles.heading}>yalive</h1>
+        <h1 className={styles.heading}>YAQUIZ</h1>
         {caption && (
           <p className={styles.caption}>
             <span className={styles.highlight}>{caption}</span>


### PR DESCRIPTION
퀴즈 종료시 대시보드에 나타나는 yalive 워딩을 YAQUIZ로 변경하고자 합니다.